### PR TITLE
feat: add --version flag and version command

### DIFF
--- a/smithery/cli.py
+++ b/smithery/cli.py
@@ -21,7 +21,7 @@ app = typer.Typer(
 console = Console()
 
 
-def _version_callback(value: bool) -> None:
+def _version_callback(value: bool | None) -> None:
     if value:
         console.print(f"smithery {__version__}")
         raise typer.Exit()
@@ -46,6 +46,9 @@ def main(
 @app.command()
 def version() -> None:
     """Show smithery version and environment info."""
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as pkg_version
+
     console.print(f"smithery {__version__}")
     console.print(f"Python {sys.version.split()[0]}")
 
@@ -55,8 +58,6 @@ def version() -> None:
         ("peft", "PEFT"),
     ]:
         try:
-            from importlib.metadata import version as pkg_version
-
             ver = pkg_version(pkg)
             extra = ""
             if pkg == "torch":
@@ -64,7 +65,7 @@ def version() -> None:
 
                 extra = f" (CUDA {torch.version.cuda})" if torch.cuda.is_available() else " (CPU)"
             console.print(f"{label} {ver}{extra}")
-        except Exception:
+        except (PackageNotFoundError, ImportError):
             console.print(f"{label}: not installed")
 
     console.print(f"Platform: {platform.system()} {platform.release()} ({platform.machine()})")

--- a/smithery/cli.py
+++ b/smithery/cli.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import platform
+import sys
 from pathlib import Path
 from typing import Annotated
 
 import typer
 from rich.console import Console
+
+from smithery import __version__
 
 app = typer.Typer(
     name="smithery",
@@ -15,6 +19,56 @@ app = typer.Typer(
     rich_markup_mode="rich",
 )
 console = Console()
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(f"smithery {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: Annotated[
+        bool | None,
+        typer.Option(
+            "--version",
+            "-V",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show version and exit.",
+        ),
+    ] = None,
+) -> None:
+    """Forge tool-calling models from your API definitions."""
+
+
+@app.command()
+def version() -> None:
+    """Show smithery version and environment info."""
+    console.print(f"smithery {__version__}")
+    console.print(f"Python {sys.version.split()[0]}")
+
+    for pkg, label in [
+        ("torch", "PyTorch"),
+        ("transformers", "Transformers"),
+        ("peft", "PEFT"),
+    ]:
+        try:
+            from importlib.metadata import version as pkg_version
+
+            ver = pkg_version(pkg)
+            extra = ""
+            if pkg == "torch":
+                import torch
+
+                extra = f" (CUDA {torch.version.cuda})" if torch.cuda.is_available() else " (CPU)"
+            console.print(f"{label} {ver}{extra}")
+        except Exception:
+            console.print(f"{label}: not installed")
+
+    console.print(f"Platform: {platform.system()} {platform.release()} ({platform.machine()})")
+
 
 # ---------------------------------------------------------------------------
 # Sub-command groups

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,34 @@
+"""Tests for CLI version flag and command."""
+
+from typer.testing import CliRunner
+
+from smithery import __version__
+from smithery.cli import app
+
+runner = CliRunner()
+
+
+def test_version_flag() -> None:
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "smithery" in result.stdout
+    assert __version__ in result.stdout
+
+
+def test_version_short_flag() -> None:
+    result = runner.invoke(app, ["-V"])
+    assert result.exit_code == 0
+    assert "smithery" in result.stdout
+
+
+def test_version_command() -> None:
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "Python" in result.stdout
+    assert "Platform:" in result.stdout
+
+
+def test_version_command_shows_smithery_version() -> None:
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert __version__ in result.stdout

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -19,6 +19,7 @@ def test_version_short_flag() -> None:
     result = runner.invoke(app, ["-V"])
     assert result.exit_code == 0
     assert "smithery" in result.stdout
+    assert __version__ in result.stdout
 
 
 def test_version_command() -> None:


### PR DESCRIPTION
## Summary

- Add `--version` / `-V` flag to print smithery version and exit
- Add `smithery version` command showing Python version, optional dependency versions (PyTorch, Transformers, PEFT), and platform info
- Gracefully handles missing optional dependencies
- 4 unit tests using `typer.testing.CliRunner`

Closes #28

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `pytest tests/unit/test_cli.py` — 4/4 pass
- [x] `test_version_flag` — verifies `--version` prints version string
- [x] `test_version_short_flag` — verifies `-V` works
- [x] `test_version_command` — verifies `smithery version` shows Python and Platform
- [x] `test_version_command_shows_smithery_version` — verifies version string in output