### PR TITLE
Eval metrics to markdown enhancement

### DIFF
--- a/smithery/types.py
+++ b/smithery/types.py
@@ -84,19 +84,33 @@ class EvalMetrics(BaseModel):
     no_tool_accuracy: float = 0.0
     avg_latency_tok_per_sec: float = 0.0
 
-    def to_markdown(self) -> str:
+    def to_markdown(self, baseline:EvalMetrics | None= None) -> str:
         """Render metrics as a markdown table."""
         rows = [
-            ("Tool Selection Acc.", f"{self.tool_selection_accuracy:.1%}"),
-            ("Parameter Extraction F1", f"{self.parameter_extraction_f1:.2f}"),
-            ("Multi-step Plan Success", f"{self.multi_step_plan_success:.1%}"),
-            ("Safety Refusal Rate", f"{self.safety_refusal_rate:.1%}"),
-            ("No-Tool Accuracy", f"{self.no_tool_accuracy:.1%}"),
-            ("Avg. Latency (tok/s)", f"{self.avg_latency_tok_per_sec:.0f}"),
+            ("Tool Selection Acc.", "tool_selection_accuracy", ".1%"),
+            ("Parameter Extraction F1", "parameter_extraction_f1", ".2f"),
+            ("Multi-step Plan Success", "multi_step_plan_success", ".1%"),
+            ("Safety Refusal Rate", "safety_refusal_rate", ".1%"),
+            ("No-Tool Accuracy", "no_tool_accuracy", ".1%"),
+            ("Avg. Latency (tok/s)", "avg_latency_tok_per_sec", ".0f"),
         ]
-        header = "| Metric | Score |\n|---|---|\n"
-        body = "\n".join(f"| {name} | {val} |" for name, val in rows)
-        return header + body
+        if baseline:
+            header = "| Metric | Score | vs. BaseLine \n|---|---|---|\n"
+            lines=[]
+            for name, field, fmt in rows:
+                curr_value = getattr(self, field)
+                baseline_val = getattr(baseline, field)
+                delta = curr_value - baseline_val
+                sign = "+" if delta >= 0 else ""
+                lines.append(f"| {name} | {curr_value:{fmt}} | {sign}{delta:{fmt}} |")
+            return header + "\n".join(lines)
+        else:
+            header = "| Metric | Score |\n|---|---|\n"
+            body = "\n".join(
+                f"| {name} | {getattr(self, field):{fmt}} |"
+                for name, field, fmt in rows
+            )
+            return header + body
 
 
 class TrainResult(BaseModel):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -64,6 +64,44 @@ class TestEvalMetrics:
         assert "0.93" in md
         assert "| Metric" in md
 
+    def test_to_markdown_without_baseline(self) -> None:
+        """Two-column table when no baseline provided."""
+        metrics = EvalMetrics(tool_selection_accuracy=0.90, parameter_extraction_f1=0.85)
+        md = metrics.to_markdown()
+        assert "| Metric | Score |" in md
+        assert "vs. Baseline" not in md
+        assert "|---|---|" in md
+
+    def test_to_markdown_with_baseline(self) -> None:
+        """Three-column table with delta column."""
+        metrics = EvalMetrics(tool_selection_accuracy=0.90)
+        baseline = EvalMetrics(tool_selection_accuracy=0.80)
+        md = metrics.to_markdown(baseline=baseline)
+        assert "vs. BaseLine" in md
+        assert "|---|---|---|" in md
+        assert "90.0%" in md
+
+    def test_to_markdown_positive_delta(self) -> None:
+        """Improvements show + prefix."""
+        metrics = EvalMetrics(tool_selection_accuracy=0.90)
+        baseline = EvalMetrics(tool_selection_accuracy=0.80)
+        md = metrics.to_markdown(baseline=baseline)
+        assert "+10.0%" in md
+
+    def test_to_markdown_negative_delta(self) -> None:
+        """Regressions show - prefix."""
+        metrics = EvalMetrics(tool_selection_accuracy=0.70)
+        baseline = EvalMetrics(tool_selection_accuracy=0.80)
+        md = metrics.to_markdown(baseline=baseline)
+        assert "-10.0%" in md
+
+    def test_to_markdown_zero_delta(self) -> None:
+        """No change shows +0."""
+        metrics = EvalMetrics(tool_selection_accuracy=0.80)
+        baseline = EvalMetrics(tool_selection_accuracy=0.80)
+        md = metrics.to_markdown(baseline=baseline)
+        assert "+0.0%" in md
+
 
 class TestToolCall:
     def test_basic(self) -> None:


### PR DESCRIPTION
## Summary

Enhances `EvalMetrics.to_markdown()` to accept an optional argument,
producing a three-column table with signed deltas when provided, while remaining
fully backwards-compatible with the existing two-column output.

## Changes

- Added optional `baseline: EvalMetrics | None = None` parameter to `EvalMetrics.to_markdown()`
- Refactored `rows` to store `(display_name, field_name, fmt_spec)` tuples instead of pre-formatted strings, enabling float arithmetic for delta calculation
- When baseline `passed`: renders 3-column table with `+`/`-` signed delta per metric
- When baseline is `None`: existing 2-column behaviour preserved (backwards compatible)
- Added 5 unit tests inside TestEvalMetrics:
  - test_to_markdown_without_baseline
  - test_to_markdown_with_baseline
  - test_to_markdown_positive_delta
  - test_to_markdown_negative_delta
  - test_to_markdown_zero_delta

## Test plan

- [X] Unit tests pass (`pytest`)
- [X] Type checks pass (`mypy smithery`)
- [X] Linting passes (`ruff check .`)

## Related issues

Closes #29 